### PR TITLE
[IMP] Feature #18331 - Solved issue of set to quote button not visible on duplicated sale, purchase smart button editable, shipment plan tab visible on draft status

### DIFF
--- a/bista_sale_multi_ship/views/sale_order_view.xml
+++ b/bista_sale_multi_ship/views/sale_order_view.xml
@@ -51,7 +51,7 @@
                  </xpath>
                 <xpath expr="//page[last()]" position="after">
                     <page name="shipping_lines" string="Shipment Plan"
-                          attrs="{'invisible': ['|', ('split_shipment', '=', False), ('id', '=', False)]}">
+                        attrs="{'invisible': ['|', ('state', 'in', ['draft', 'quote_approval', 'quote_confirm', 'sent', 'cancel']), ('split_shipment', '=', False)]}">
                         <!-- <div>
                             <group>
                                 <group name="third_party_billing" string="Third Party Billing"


### PR DESCRIPTION
Solved issue of set to quote button not visible on duplicated sale, purchase smart button editable, shipment plan tab visible on draft status.