### PR TITLE
[IMP] Bug #18863 - display available stock qty widget for normal and multi ship sales

### DIFF
--- a/bista_orders_report/models/sale_order_line.py
+++ b/bista_orders_report/models/sale_order_line.py
@@ -47,7 +47,8 @@ class SaleOrderLine(models.Model):
     def get_return_quantity(self):
         for sline in self:
             return_pickings = sline.order_id.picking_ids.filtered(
-                lambda x: 'Return of' in x.origin)
+                lambda x: x.origin and "Return of" in x.origin
+            )
             return_lines = return_pickings.move_ids_without_package.filtered(
                 lambda x: x.product_id == sline.product_id and x.state in (
                     'done'))

--- a/bista_sale_multi_ship/models/sale_multi_ship.py
+++ b/bista_sale_multi_ship/models/sale_multi_ship.py
@@ -498,7 +498,8 @@ class SaleMultiShipQtyLines(models.Model):
         # We first loop over the SO lines to group them by
         # warehouse and schedule
         # date in order to batch the read of the quantities computed field.
-        for line in self.filtered(lambda l: l.state in ('draft', 'sent')):
+        """ Bug #18863 - Override code for display proper stock qty widget """
+        for line in self.filtered(lambda l: l.state not in ("sale", "done", "cancel")):
             if not (line.product_id and line.display_qty_widget):
                 continue
             grouped_lines[(

--- a/bista_sales_approval/__manifest__.py
+++ b/bista_sales_approval/__manifest__.py
@@ -23,6 +23,10 @@
         "views/sale_portal_template.xml",
         "wizard/so_reject_reason_view.xml",
     ],
+    "assets": {
+        "web.assets_backend": ["bista_sales_approval/static/src/js/**/*"],
+        "web.assets_qweb": ["bista_sales_approval/static/src/xml/**/*"],
+    },
     "installable": True,
     "application": False,
     "auto_install": False,

--- a/bista_sales_approval/models/sale_order.py
+++ b/bista_sales_approval/models/sale_order.py
@@ -6,6 +6,7 @@
 #
 ##############################################################################
 from datetime import datetime
+from collections import defaultdict
 
 from odoo import api, models, fields, _
 from lxml import etree
@@ -202,7 +203,14 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     # Override method to display qty widget on custom status.
-    @api.depends("product_type", "product_uom_qty", "qty_delivered", "state", "move_ids", "product_uom")
+    @api.depends(
+        "product_type",
+        "product_uom_qty",
+        "qty_delivered",
+        "state",
+        "move_ids",
+        "product_uom",
+    )
     def _compute_qty_to_deliver(self):
         """Compute the visibility of the inventory widget."""
         for line in self:
@@ -219,6 +227,130 @@ class SaleOrderLine(models.Model):
                     line.display_qty_widget = True
             else:
                 line.display_qty_widget = False
+
+    @api.depends(
+        "product_id",
+        "customer_lead",
+        "product_uom_qty",
+        "product_uom",
+        "order_id.commitment_date",
+        "move_ids",
+        "move_ids.forecast_expected_date",
+        "move_ids.forecast_availability",
+    )
+    def _compute_qty_at_date(self):
+        """Compute the quantity forecasted of product at delivery date. There are
+        two cases:
+         1. The quotation has a commitment_date, we take it as delivery date
+         2. The quotation hasn't commitment_date, we compute the estimated delivery
+            date based on lead time"""
+        treated = self.browse()
+        # If the state is already in sale the picking is created and a simple forecasted quantity isn't enough
+        # Then used the forecasted data of the related stock.move
+        for line in self.filtered(lambda l: l.state == "sale"):
+            if not line.display_qty_widget:
+                continue
+            moves = line.move_ids.filtered(lambda m: m.product_id == line.product_id)
+            line.forecast_expected_date = max(
+                moves.filtered("forecast_expected_date").mapped(
+                    "forecast_expected_date"
+                ),
+                default=False,
+            )
+            line.qty_available_today = 0
+            line.free_qty_today = 0
+            for move in moves:
+                line.qty_available_today += move.product_uom._compute_quantity(
+                    move.reserved_availability, line.product_uom
+                )
+                line.free_qty_today += move.product_id.uom_id._compute_quantity(
+                    move.forecast_availability, line.product_uom
+                )
+            line.scheduled_date = line.order_id.commitment_date or line._expected_date()
+            line.virtual_available_at_date = False
+            treated |= line
+
+        qty_processed_per_product = defaultdict(lambda: 0)
+        grouped_lines = defaultdict(lambda: self.env["sale.order.line"])
+        # We first loop over the SO lines to group them by warehouse and schedule
+        # date in order to batch the read of the quantities computed field.
+        """ Bug #18863 - Override code for display proper stock qty widget """
+        for line in self.filtered(lambda l: l.state not in ("sale", "done", "cancel")):
+            if not (line.product_id and line.display_qty_widget):
+                continue
+            grouped_lines[
+                (
+                    line.warehouse_id.id,
+                    line.order_id.commitment_date or line._expected_date(),
+                )
+            ] |= line
+
+        for (warehouse, scheduled_date), lines in grouped_lines.items():
+            product_qties = (
+                lines.mapped("product_id")
+                .with_context(to_date=scheduled_date, warehouse=warehouse)
+                .read(
+                    [
+                        "qty_available",
+                        "free_qty",
+                        "virtual_available",
+                    ]
+                )
+            )
+            qties_per_product = {
+                product["id"]: (
+                    product["qty_available"],
+                    product["free_qty"],
+                    product["virtual_available"],
+                )
+                for product in product_qties
+            }
+            for line in lines:
+                line.scheduled_date = scheduled_date
+                (
+                    qty_available_today,
+                    free_qty_today,
+                    virtual_available_at_date,
+                ) = qties_per_product[line.product_id.id]
+                line.qty_available_today = (
+                    qty_available_today - qty_processed_per_product[line.product_id.id]
+                )
+                line.free_qty_today = (
+                    free_qty_today - qty_processed_per_product[line.product_id.id]
+                )
+                line.virtual_available_at_date = (
+                    virtual_available_at_date
+                    - qty_processed_per_product[line.product_id.id]
+                )
+                line.forecast_expected_date = False
+                product_qty = line.product_uom_qty
+                if (
+                    line.product_uom
+                    and line.product_id.uom_id
+                    and line.product_uom != line.product_id.uom_id
+                ):
+                    line.qty_available_today = line.product_id.uom_id._compute_quantity(
+                        line.qty_available_today, line.product_uom
+                    )
+                    line.free_qty_today = line.product_id.uom_id._compute_quantity(
+                        line.free_qty_today, line.product_uom
+                    )
+                    line.virtual_available_at_date = (
+                        line.product_id.uom_id._compute_quantity(
+                            line.virtual_available_at_date, line.product_uom
+                        )
+                    )
+                    product_qty = line.product_uom._compute_quantity(
+                        product_qty, line.product_id.uom_id
+                    )
+                qty_processed_per_product[line.product_id.id] += product_qty
+            treated |= lines
+        remaining = self - treated
+        remaining.virtual_available_at_date = False
+        remaining.scheduled_date = False
+        remaining.forecast_expected_date = False
+        remaining.free_qty_today = False
+        remaining.qty_available_today = False
 
 
 class SaleApprovalLog(models.Model):

--- a/bista_sales_approval/static/src/js/qty_widget.js
+++ b/bista_sales_approval/static/src/js/qty_widget.js
@@ -1,0 +1,28 @@
+odoo.define("bista_sales_approval.QtyAtDateWidget", function(require) {
+    "use strict";
+
+    var utils = require("web.utils");
+    var QtyAtDateWidget = require("sale_stock.QtyAtDateWidget");
+
+    QtyAtDateWidget.include({
+        _updateData: function() {
+            // add some data to simplify the template
+            if (this.data.scheduled_date) {
+                var qty_to_deliver = utils.round_decimals(this.data.qty_to_deliver, this.fields.qty_to_deliver.digits[1]);
+                if (this.data.state === "sale") {
+                    this.data.will_be_fulfilled = utils.round_decimals(this.data.free_qty_today, this.fields.free_qty_today.digits[1]) >= qty_to_deliver
+                } else {
+                    this.data.will_be_fulfilled = utils.round_decimals(this.data.virtual_available_at_date, this.fields.virtual_available_at_date.digits[1]) >= qty_to_deliver
+                }
+                this.data.will_be_late = this.data.forecast_expected_date && this.data.forecast_expected_date > this.data.scheduled_date;
+                if (!["sale", "done", "cancel"].includes(this.data.state)) {
+                    // Moves aren't created yet, then the forecasted is only based on virtual_available of quant
+                    this.data.forecasted_issue = !this.data.will_be_fulfilled && !this.data.is_mto;
+                } else {
+                    // Moves are created, using the forecasted data of related moves
+                    this.data.forecasted_issue = !this.data.will_be_fulfilled || this.data.will_be_late;
+                }
+            }
+        },
+    });
+});

--- a/bista_sales_approval/static/src/xml/sale_stock.xml
+++ b/bista_sales_approval/static/src/xml/sale_stock.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-inherit="sale_stock.QtyDetailPopOver">
+        <xpath expr="//tbody/t[1]" position="attributes">
+            <attribute name="t-if">!data.is_mto and !['sale', 'done', 'cancel'].includes(data.state)</attribute>
+        </xpath>
+        <xpath expr="//tbody/t[2]" position="attributes">
+            <attribute name="t-elif">data.is_mto and !['sale', 'done', 'cancel'].includes(data.state)</attribute>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
Display available stock qty widget for normal and multi-ship sales