### PR TITLE
Remove fiscal postiion from invoice when invoice genrate from BC sale order

### DIFF
--- a/bista_bigcommerce_extend/models/__init__.py
+++ b/bista_bigcommerce_extend/models/__init__.py
@@ -3,3 +3,4 @@ from . import product_template
 from . import big_commerce_config
 from . import stock_picking
 from . import sale_order
+from . import account_move

--- a/bista_bigcommerce_extend/models/account_move.py
+++ b/bista_bigcommerce_extend/models/account_move.py
@@ -1,0 +1,20 @@
+
+from odoo import api, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.model
+    def create(self, vals):
+        """Remove fiscal position.
+
+        Make blank fiscal position if invoce create from
+        bigcommerce order.
+        """
+        if self._context.get('active_model') == 'sale.order':
+            sale_order_id = self.env['sale.order'].browse(
+                self._context.get('active_id'))
+            if sale_order_id.big_commerce_order_id:
+                vals.update({'fiscal_position_id': False})
+        return super(AccountMove, self).create(vals)


### PR DESCRIPTION
Updated fiscal position as blank when invoice created from bigcommerce sale order.