### PR TITLE
[IMP] Resolved Bug #18870 quotation changes

### DIFF
--- a/bista_report_header_footer/report/report_header_footer_view.xml
+++ b/bista_report_header_footer/report/report_header_footer_view.xml
@@ -26,7 +26,7 @@
         <t t-set="company" t-value="user.company_id"/>
         <div t-attf-class="header o_company_#{company.id}_layout" t-att-style="report_header_style">
             <div class="o_boxed_header">
-                <div class="row mb-3">
+                <div class="row mb-2 mt-0">
                     <div class="col-6">
                         <img t-if="company.logo" t-att-src="image_data_uri(company.logo)" alt="Logo"/>
 <!--                        <div t-field="company.partner_id"-->
@@ -41,7 +41,10 @@
         </div>
 
         <div class="article o_report_layout_standard" t-att-data-oe-model="o and o._name" t-att-data-oe-id="o and o.id" t-att-data-oe-lang="o and o.env.context.get('lang')">
-            <div class="pt-4">
+            <div name="report_tagline">
+                <t t-out="report_tagline"/>
+            </div>
+            <div class="pt-4" >
                 <!-- This div ensures that the address is not cropped by the header. -->
                 <t t-call="bista_report_header_footer.custom_address_layout"/>
             </div>

--- a/bista_sale/models/sale_order.py
+++ b/bista_sale/models/sale_order.py
@@ -158,6 +158,12 @@ class SaleOrder(models.Model):
             })
         return res
 
+    def compute_customer_preview_url(self):
+        base_url = self.env['ir.config_parameter'].get_param('web.base.url')
+        access_token = self._portal_ensure_token()
+        url = base_url + '/my/orders/' + str(self.id) + "?" + access_token
+        return url
+
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 

--- a/bista_sale/report/sale.xml
+++ b/bista_sale/report/sale.xml
@@ -10,19 +10,54 @@
             <t t-set="o" t-value="doc.with_context(lang=doc.partner_id.lang)"/>
             <div class="page">
                 <div t-set="address">
-                    <strong>Customer Detail:</strong>
+                    <strong>Prepared For:</strong>
                     <t t-if="o.partner_id.parent_id.name">
                         <div>
+                            <strong> Name/Account :</strong><br/>
                             <span t-field="o.partner_id.name"/>
                             <br/>
                             <span t-field="o.partner_id.parent_id.name"/>
                         </div>
-                        <div t-field="doc.partner_id"
-                             t-options='{"widget": "contact", "fields": ["address", "phone"], "no_marker": True, "phone_icons": True}'/>
+                            <div>
+                            <strong>Customer Address:</strong><br/>
+                                <span  t-field="o.partner_id.street"/>
+                                <br/>
+                                <span t-field="o.partner_id.street2"/>
+                                <br/>
+                                <span t-field="o.partner_id.city"/>
+                                <span t-field="o.partner_id.zip"/>
+                                <br/>
+                              </div>
+                                <strong>Email:</strong>
+                                <span t-field="o.partner_id.email"/>
+                                <br/>
+                                <strong>Phone:</strong>
+                                <span t-field="o.partner_id.phone"/>
+
+<!--                        <div t-field="doc.partner_id"-->
+<!--                             t-options='{"widget": "contact", "fields": ["address", "phone"], "no_marker": True, "phone_icons": True}'/>-->
                     </t>
                     <t t-else="">
-                        <div t-field="doc.partner_id"
-                             t-options='{"widget": "contact", "fields": ["address","name","phone"], "no_marker": True, "phone_icons": True}'/>
+                        <div>
+                           <strong> Name/Account:</strong><br/>
+                            <span t-field="o.partner_id.name"/>
+                            <br/>
+                            <strong>Customer Address:</strong><br/>
+                                <div t-if="o.partner_id.street">
+                                <span t-field="o.partner_id.street"/>
+                                <span t-field="o.partner_id.street2"/><br/>
+                                <span t-field="o.partner_id.city"/>
+                                <span t-field="o.partner_id.zip"/>
+                                <br/>
+                                </div>
+                                <strong> Email:</strong>
+                                <span t-field="o.partner_id.email"/>
+                                <br/>
+                                <strong> Phone:</strong>
+                                <span t-field="o.partner_id.phone"/>
+                        </div>
+<!--                        <div t-field="doc.partner_id"-->
+<!--                             t-options='{"widget": "contact", "fields": ["address","name","phone"], "no_marker": True, "phone_icons": True}'/>-->
                     </t>
                 </div>
                 <t t-set="report_info"
@@ -36,21 +71,25 @@
                         </strong>
                     </h4>
                     <t t-if="doc.state in ['draft','sent','quote_approval','quote_confirm']">
-                        <strong>Quotation Date:</strong>
+<!--                        <strong>Quotation Date:</strong>-->
                         <t t-esc="o.date_order" t-options='{"widget": "date"}'/>
                         <br/>
                     </t>
                     <t t-if="doc.state in ['order_booked']">
-                        <strong>Booked order date:</strong>
+<!--                        <strong>Booked order date:</strong>-->
                         <t t-esc="o.date_order" t-options='{"widget": "date"}'/>
                         <br/>
                     </t>
                     <t t-if="doc.state  in ['sale','pending_for_approval','credit_review','cancel','done']">
-                        <strong>Order Date:
+<!--                        <strong>Order Date:</strong>-->
                             <t t-esc="o.date_order" t-options='{"widget": "date"}'/>
-                        </strong>
                     </t>
                     <br/>
+                </t>
+                <t t-set="report_tagline" >
+                    <div style="margin-left: 5rem !important; margin-top: 0px !important;font-color: black;">
+                    <h5>Thank you for requesting this quote --Inspiration is just an order away!</h5>
+                    </div>
                 </t>
                 <t t-set="information_block">
                     <div class="row">
@@ -58,19 +97,29 @@
                             <t t-if="doc.split_shipment">
                             </t>
                             <t t-else="">
-                                <strong>Shipping Details:</strong>
+                                <strong>Shipping Address:</strong>
                                 <t t-if="o.partner_shipping_id.parent_id.name">
                                     <div>
                                         <span t-field="doc.partner_shipping_id.name"/>
                                         <br/>
                                         <span t-field="o.partner_shipping_id.parent_id.name"/>
                                     </div>
-                                    <div t-field="doc.partner_shipping_id"
-                                         t-options='{"widget": "contact", "fields": ["address", "phone"], "no_marker": True, "phone_icons": True}'/>
+                                    <span t-field="o.partner_shipping_id.street"/>
+                                    <span t-field="o.partner_shipping_id.street2"/>
+                                    <br/>
+                                    <span t-field="o.partner_shipping_id.city"/>
+                                    <span t-field="o.partner_shipping_id.zip"/>
                                 </t>
                                 <t t-else="">
-                                    <div t-field="doc.partner_shipping_id"
-                                         t-options='{"widget": "contact", "fields": ["address", "name","phone"], "no_marker": True, "phone_icons": True}'/>
+<!--                                    <div t-field="doc.partner_shipping_id"-->
+<!--                                         t-options='{"widget": "contact", "fields": ["address", "name","phone"], "no_marker": True, "phone_icons": True}'/>-->
+                                    <br/>
+                                    <span t-field="doc.partner_shipping_id.name"/><br/>
+                                    <span t-field="o.partner_shipping_id.street"/><br/>
+                                    <span t-field="o.partner_shipping_id.street2"/>
+                                    <br/>
+                                    <span t-field="o.partner_shipping_id.city"/>
+                                    <span t-field="o.partner_shipping_id.zip"/>
                                 </t>
                             </t>
                         </div>
@@ -78,55 +127,67 @@
                 </t>
                 <t t-set="custom_information_block">
                     <div>
-                        <t t-if="doc.state in ['draft','sent','quote_approval','quote_confirm']">
-                            <strong>Quotation:</strong>
-                            <t t-esc="doc.name"/>
-                            <br/>
-                        </t>
+<!--                        <t t-if="doc.state in ['draft','sent','quote_approval','quote_confirm']">-->
+<!--                            <strong>Quotation:</strong>-->
+<!--                            <t t-esc="doc.name"/>-->
+<!--                            <br/>-->
+<!--                        </t>-->
                         <t>
                             <strong>Need By Date:</strong>
                             <t t-esc="doc.commitment_date" t-options='{"widget": "date"}'/>
                             <br/>
                         </t>
+                        <t>
+                            <strong>Event Date:</strong>
+                            <t t-esc="doc.date_order" t-options='{"widget": "date"}'/>
+                            <br/>
+                        </t>
 
-                        <t t-if="doc.state in ['sale','order_booked','credit_review','pending_for_approval','cancel','done']">
-                            <strong>Sale Order:</strong>
-                            <t t-esc="doc.name"/>
-                            <br/>
-                        </t>
-                        <t t-if="doc.state in ['draft','sent','quote_approval','quote_confirm']">
-                            <strong>Quotation Date:</strong>
-                            <t t-esc="o.date_order" t-options='{"widget": "date"}'/>
-                            <br/>
-                        </t>
-                        <t t-if="doc.state in ['sale','order_booked','credit_review','pending_for_approval','cancel','done']">
-                            <strong>Order Date:</strong>
-                            <span t-esc="o.date_order" t-options='{"widget": "date"}'>
-                            </span>
-                            <br/>
-                        </t>
-                        <strong>Customer Ref:</strong>
-                        <t t-esc="doc.client_order_ref"/>
-                        <br/>
-                        <t t-if="doc.state not in ['sale','order_booked','credit_review','pending_for_approval','cancel','done']">
+<!--                        <t t-if="doc.state in ['sale','order_booked','credit_review','pending_for_approval','cancel','done']">-->
+<!--                            <strong>Sale Order:</strong>-->
+<!--                            <t t-esc="doc.name"/>-->
+<!--                            <br/>-->
+<!--                        </t>-->
+<!--                        <t t-if="doc.state in ['draft','sent','quote_approval','quote_confirm']">-->
+<!--                            <strong>Quotation Date:</strong>-->
+<!--                            <t t-esc="o.date_order" t-options='{"widget": "date"}'/>-->
+<!--                            <br/>-->
+<!--                        </t>-->
+<!--                        <t t-if="doc.state in ['sale','order_booked','credit_review','pending_for_approval','cancel','done']">-->
+<!--                            <strong>Order Date:</strong>-->
+<!--                            <span t-esc="o.date_order" t-options='{"widget": "date"}'>-->
+<!--                            </span>-->
+<!--                            <br/>-->
+<!--                        </t>-->
+<!--                        <strong>Customer Ref:</strong>-->
+<!--                        <t t-esc="doc.client_order_ref"/>-->
+<!--                        <br/>-->
+                        <t t-if="doc.state not in ['sale','credit_review','pending_for_approval','cancel','done']">
                         <strong>Valid Until:</strong>
                         <t t-esc="doc.validity_date" t-options='{"widget": "date"}'/>
                         <br/>
                         </t>
-                        <strong>Salesperson:</strong>
+                        <strong>Quoted By:</strong>
                         <t t-esc="o.user_id.name"/>
+                        <br/>
+                        <strong>Email:</strong>
+                        <t t-esc="o.user_id.email"/>
+                        <br/>
+                        <strong>Phone:</strong>
+                        <t t-esc="o.user_id.phone"/>
                         <br/>
                     </div>
                 </t>
             </div>
+
         </xpath>
-        <xpath expr="//p[@t-field='doc.note']" position="replace">
-            <div style="margin-top:40px;">
-                <strong style="border-bottom:solid 1px;">Order Terms and Conditions</strong>
-                <p class="mb-1" t-field="doc.note" style="margin-left: 50px;"/>
-                <!--                  <span t-field="doc.note"/>-->
-            </div>
-        </xpath>
+<!--        <xpath expr="//p[@t-field='doc.note']" position="replace">-->
+<!--            <div style="margin-top:40px;" t-if="doc.note">-->
+<!--                <strong style="border-bottom:solid 1px;">Order Terms and Conditions</strong>-->
+<!--                <p class="mb-1" t-field="doc.note" style="margin-left: 50px;"/>-->
+<!--                                  <span t-field="doc.note"/>-->
+<!--            </div>-->
+<!--        </xpath>-->
         <xpath expr="//table[hasclass('table','table-sm','o_main_table')]" position="before">
             <span style="font-size:20px;">
                 <strong>Product Details</strong>
@@ -137,7 +198,7 @@
             <thead>
                 <tr style="border-top: 1px solid black;">
                     <th style="border: none;" name="th_sn" class="text-center">
-                        <strong>SN</strong>
+                        <strong></strong>
                     </th>
                     <th colspan="2" style=" border-collapse: collapse;
                    border: none;" name="image" class="text-center">Description
@@ -154,6 +215,9 @@
                     <th style=" border-collapse: collapse;
                    border: none;" name="th_priceunit" class="text-center">Price
                     </th>
+                    <th style=" border-collapse: collapse;
+                   border: none;" name="th_discount" class="text-center">Discount
+                    </th>
                     <th name="th_taxes" t-if="line_taxes" class="text-center"
                         style=" border-collapse: collapse;border: none; display:none !important;">
                         <span>Taxes</span>
@@ -161,7 +225,7 @@
                     <th style=" border-collapse: collapse;
                    border: none;padding-left:15px;" name="th_subtotal" class="text-right">
                         <span groups="account.group_show_line_subtotals_tax_excluded">
-                            Total
+                            Subtotal
                         </span>
                         <span groups="account.group_show_line_subtotals_tax_included">
                             Total Price
@@ -198,8 +262,8 @@
                     <b>
                         <span t-field="line.name"/>
                     </b>
-                    <br/>
-                    <span t-field="line.product_id.default_code"/>
+<!--                    <br/>-->
+<!--                    <span t-field="line.product_id.default_code"/>-->
                     <!-- <br/> -->
                     <!-- <span>Format:</span> -->
                     <!--                        <span t-field="line.product_id.format"/>-->
@@ -242,6 +306,10 @@
                         </t>
                     </span>
                 </td>
+                <td style="border-top: 1px solid black; border-left: none;
+                     border-right: none; border-bottom: 1px solid black;" name="td_discount" class="text-center">
+                    <span t-field="line.discount"/>%
+                </td>
                 <td t-if="line_taxes" name="td_taxes" class="text-center" style="border-top: 1px solid black; border-left: none;
                      border-right: none; border-bottom: 1px solid black;display:none !important;">
                     <span t-esc="', '.join(map(lambda x: (x.name), line.tax_id))"/>
@@ -280,16 +348,16 @@
         </xpath>
         <!-- added total saving  beside total summery table  -->
         <xpath expr="//div[@name='so_total_summary']" position="replace">
-            <div class="clearfix row" name="so_total_summary">
-                <div class="col-6">
-                    <span style="color:black;">
-                        <b>Total Savings:
-                        </b>
-                        <span t-esc="sum((line.product_uom_qty*line.price_unit)-line.price_subtotal for line in doc.order_line)"
-                              t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
-                    </span>
-                </div>
-                <div>
+            <div class="clearfix row" name="so_total_summary" style="page-break-inside:avoid;">
+                <div class="col-6"/>
+<!--                    <span style="color:black;">-->
+<!--                        <b>Total Savings:-->
+<!--                        </b>-->
+<!--                        <span t-esc="sum((line.product_uom_qty*line.price_unit)-line.price_subtotal for line in doc.order_line)"-->
+<!--                              t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>-->
+<!--                    </span>-->
+<!--                </div>-->
+                <div name="footer_table">
                     <table style="width:170pt;margin-left:190px; border-left: 1px solid black; border-right: 1px solid black;">
                         <tr style="border-top: 1px solid black;">
                             <td style="height:1px; color: black; padding-left:10px;"
@@ -313,6 +381,16 @@
                             </td>
                         </tr>
                         <tr style="border-top: 1px solid black;">
+                            <td style="height:1.5px;background-color: white; padding-left:10px;"
+                                class="text-left">
+                                <strong class="text-right">Coupon Code</strong>
+                            </td>
+                            <td style="padding-right:8px; height:1.5px;border-left: 1px solid black; color:black; background-color: white;"
+                                class="text-right">
+                                <span t-esc="8456789"/>
+                            </td>
+                        </tr>
+                        <tr style="border-top: 1px solid black;">
                             <td style="padding-top:5px;color: black; padding-left:10px; background-color: white;"
                                 class="text-left">
                                 <t t-if="doc.carrier_id">
@@ -333,6 +411,16 @@
                                 </t>
                             </td>
                         </tr>
+<!--                        <tr style="border-top: 1px solid black;">-->
+<!--                            <td style="height:1.5px;background-color: white; padding-left:10px;"-->
+<!--                                class="text-left">-->
+<!--                                <strong class="text-right">Speed</strong>-->
+<!--                            </td>-->
+<!--                            <td style="padding-right:8px; height:1.5px;border-left: 1px solid black; color:black; background-color: white;"-->
+<!--                                class="text-right">-->
+<!--                                <span t-esc="hrs"/>-->
+<!--                            </td>-->
+<!--                        </tr>-->
                         <tr style="background-color: #f56343; border-top: 1px solid black;">
                             <td style="padding-left:10px;color: black;" class="text-left">
                                 <strong class="border-black o_subtotal;text-right">Total</strong>
@@ -341,9 +429,80 @@
                                 <strong t-field="doc.amount_total"/>
                             </td>
                         </tr>
+                        <tr style=" border-top: 1px solid black; border-bottom: 1px solid black;">
+                            <td style="padding-left:10px;color: black;" class="text-left">
+                                <strong class="border-black o_subtotal;text-right">Total Savings</strong>
+                            </td>
+                            <td style="padding-right:8px;color: black;border-left: 1px solid black; border-bottom: 1px solid black;" class="text-right">
+                                <strong t-esc="sum((line.product_uom_qty*line.price_unit)-line.price_subtotal for line in doc.order_line)"
+                                        t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                            </td>
+                        </tr>
                     </table>
                 </div>
             </div>
         </xpath>
+
+        <xpath expr="//p[@t-field='doc.note']" position="after">
+            <div>
+                <div style="font-color: white;">
+                    <div class="text-center bg-light" style="margin-top:10px;">
+                        <p class="mt-5" style="margin-left: 325px;width:26%; height:40pt;background-color:red;">
+                            <a t-att-href="doc.compute_customer_preview_url()" class="btn btn-link" role="button">Proceed to
+                                Checkout
+                            </a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="text-center">
+                <img src='/bista_sale/static/src/img/payment_logo.png' style="max-height: 45px;"/>
+            </div>
+            <div class="text-center mt-1">
+                <div>
+                    <p>ACH / Wire Instructions available upon request.</p>
+                    <strong>Interested in using a Purchase Order, click here:<a href=" https://bkp.al/PO" class="btn btn-link" role="button"> https://bkp.al/PO</a></strong>
+                </div>
+            </div>
+        </xpath>
+
+        <xpath expr="//p[@t-field='doc.note']" position="replace"/>
+        <xpath expr="//div[@name='so_total_summary']" position="after">
+            <div class="row mt-5 mx-3" style="page-break-inside:avoid;" name="price_images">
+                <div class="col-4">
+                    <div>
+                        <img src='/bista_sale/static/src/img/price_match_.png' style="max-height: 120px;" class="ml-5"/>
+                        <a href="https://bookpal.com/price-match-guarantee" class="btn btn-link" role="button">Price
+                            Match
+                            Available
+                        </a>
+                    </div>
+                </div>
+                <div class="col-4">
+                    <div>
+                        <img src='/bista_sale/static/src/img/sale_tax_exempt.jpeg' style="max-height: 100px;"
+                             class="ml-5"/>
+                        <a href="https://bookpal.com/sales-tax-exemption/" class="btn btn-link" role="button">Sales Tax
+                            Exempt? Learn more here.
+                        </a>
+                    </div>
+                </div>
+                <div class="col-4">
+                    <div>
+                        <img src='/bista_sale/static/src/img/shipping_icon.png' style="max-height: 100px;"
+                             class="ml-5"/>
+                        <a href="https://bookpal.com/shipping-logistics" class="btn btn-link" role="button">Learn about
+                            our
+                            Shipping Options
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div style="margin-top:40px;" t-if="doc.note">
+                <strong style="border-bottom:solid 1px;">Order Terms and Conditions</strong>
+                <p class="mb-1" t-field="doc.note" style="margin-left: 50px;"/>
+            </div>
+        </xpath>
+
     </template>
 </odoo>

--- a/bista_stock_remarks/report/sale_report_template.xml
+++ b/bista_stock_remarks/report/sale_report_template.xml
@@ -3,7 +3,7 @@
     <template id="report_saleorder_document_note" inherit_id="sale.report_saleorder_document">
         <xpath expr="//div[hasclass('oe_structure')]" position="after">
             <div>
-                <h5 style="margin-top:50px;border-bottom:solid 1px;">Special Instructions and Notes</h5>
+                <h5 style="margin-top:50px;border-bottom:solid 1px;">Notes</h5>
                 <div>
                     <span class="mb4" t-field="doc.common_pick_note"/>
                 </div>


### PR DESCRIPTION
Updated the changes
1.Need to remove company address from the header in all PDFs,
2. Remove label of order date from the header it should only print the date without any label,
3.Rename the label 'Customer Details ' to 'Prepared For'. It should show like following
4 .Prepared for:
	Name/Account: Customer name
	Customer Address(remove country in address)
	email :
	phone :
6 .Need to rename 'Shipping details' to 'Shipping Address', remove the country from the shipping address
7.Remove the quotation number from the information box, After needs by date add event date, remove customer reference, rename the 8.'Salesperson' label to 'Quoted By' to only show data, and also need to add the email and phone of the salesperson after its name.
9.Rename the 'Shipping Instruction and Notes' label to 'Notes'
10.In the product details table - remove the 'SN' header, remove the taxes column, add a discount column, and rename Total to Sub Total. In the product description show only the product name then after its SKU
In bottom section - move 'Total Saving' after the Total, need to add 'Coupon Code' after taxes, need to add 'Speed' after shipping