### PR TITLE
[IMP] CR #19784 - make custom field editable after approve sale order as requested in ticket

### DIFF
--- a/bista_sale/models/sale_order.py
+++ b/bista_sale/models/sale_order.py
@@ -33,9 +33,6 @@ class SaleOrder(models.Model):
         [('waived', 'Waived'),
          ('75', '$75.00'),
          ], string="Journal Set Up Fee")
-    # journal_setup_fee = fields.Monetary(string="Journal Set Up Fee")
-    # journal_setup_fee_waived = fields.Monetary(
-    #     string="Journal Set Up Fee Waived")
     shipping_account = fields.Selection([
         ("our_account", "Our Account"),
         ("castelli_account", "Castelli's Account")], string='Shipping Account')
@@ -102,7 +99,6 @@ class SaleOrder(models.Model):
     weight_uom_name = fields.Char(
         string='Weight unit of measure label', compute="_compute_weight_uom")
     product_use = fields.Text(string='Product Use')
-    # compurl = fields.Char(string="compute url", compute="compute_url")
     acquirer_ids = fields.Many2many(
         "payment.acquirer",
         string="Available Payments",

--- a/bista_sale/views/sale_order_view.xml
+++ b/bista_sale/views/sale_order_view.xml
@@ -113,10 +113,11 @@
                     <group>
                         <group string="Tracking" name="sale_reporting">
                             <group name="utm_link" colspan="2" class="mt-0">
-                                <field name="origin"/>
-                                <field name="medium_id" readonly="0"/>
-                                <field name="source_id" readonly="0"/>
-                                <field name="campaign_id"/>
+                                <field name="origin" />
+                                <field name="opportunity_id" />
+                                <field name="medium_id" />
+                                <field name="source_id" />
+                                <field name="campaign_id" />
                             </group>
                         </group>
                     </group>

--- a/bista_sales_approval/models/sale_order.py
+++ b/bista_sales_approval/models/sale_order.py
@@ -18,6 +18,66 @@ AddState = [
     ("pending_for_approval", "Order In Approval"),
     ("sale", "Approved Order"),
 ]
+FieldsList = [
+    "acquirer_ids",
+    "user_id",
+    "am_owner",
+    "require_payment",
+    "tag_ids",
+    "opportunity_id",
+    "refer_by_company",
+    "refer_by_person",
+    "origin",
+    "medium_id",
+    "source_id",
+    "campaign_id",
+    "order_notes",
+    "gorgias_ticket",
+    "product_status_notes",
+    "product_use",
+    "white_glove_id",
+    "ce_notes",
+    "am_notes",
+    "ce_ops_acct_notes",
+    "journal_customization_ids",
+    "link_to_art_files",
+    "journal_notes",
+    "journal_setup_fee",
+    "shipping_account",
+    "so_shipping_cost",
+    "artwork_status_id",
+    "death_type_id",
+    "existing_death_order",
+    "customization_cost",
+    "shipping_to",
+    "potential_pallets",
+    "accept_pallets",
+    "has_loading_dock",
+    "inside_delivery_req",
+    "shipping_notes",
+    "fulfilment_project",
+    "project_description",
+    "status_notes",
+    "delivery_location",
+    "project_status",
+    "shipping_instruction",
+    "customization_type_ids",
+    "individual_mailer_return_address",
+    "special_insert_note",
+    "attachment_note",
+    "book_status",
+    "on_hold_reason",
+    "recipient_list_status",
+    "individual_mailer_return_receiver",
+    "recipient_list_expected",
+    "billing_notes",
+    "payment_notes",
+    "placed_from_ip",
+    "customer_po_link",
+    "is_report",
+    "report_type",
+    "report_notes",
+]
 
 
 class SaleOrder(models.Model):
@@ -165,8 +225,10 @@ class SaleOrder(models.Model):
         result = super()._fields_view_get(view_id, view_type, toolbar, submenu)
         if view_type != "form":
             return result
+        new_attrs = False
         if self.env.user.has_group("bista_sales_approval.group_approve_sale_order"):
             attrs = "{'readonly': [('state', 'in', ['sale', 'done', 'cancel'])]}"
+            new_attrs = "{'readonly': [('state', 'in', ['done', 'cancel'])]}"
         elif self.env.user.has_group("bista_sales_approval.group_create_sale_order"):
             attrs = "{'readonly': [('state', 'in', ['pending_for_approval', 'sale', 'done', 'cancel'])]}"
         elif self.env.user.has_group("bista_sales_approval.group_approve_sale_quote"):
@@ -177,6 +239,9 @@ class SaleOrder(models.Model):
         for field in doc.xpath("//field"):
             if field.attrib["name"] in ["purchase_order_count"]:
                 field.attrib["readonly"] = "1"
+            if new_attrs and field.attrib["name"] in FieldsList:
+                field.attrib["attrs"] = new_attrs
+                continue
             if field.attrib["name"] in [
                 "order_line",
                 "partner_shipping_id",


### PR DESCRIPTION
make the custom field editable after approving the sale order as requested in the ticket.