### PR TITLE
[IMP] Feature #19716 - only keep PO number link on purchase order status report

### DIFF
--- a/bista_orders_report/views/purchase_order_line_view.xml
+++ b/bista_orders_report/views/purchase_order_line_view.xml
@@ -6,15 +6,15 @@
         <field name="model">purchase.order.line</field>
         <field name="arch" type="xml">
             <tree string="Purchase Order Line" editable="top">
-                <field name="partner_id" string="Vendor"/>
+                <field name="partner_id" string="Vendor" options="{'no_open': 1}" />
                 <field name="order_id" optional="show" readonly="1" />
                 <field name="date_order"/>
                 <field name="date_planned" string="Expected Receipt Date" optional="show" readonly="1" />
-                <field name="industry_id"/>
-                <field name="product_id" readonly="1" />
+                <field name="industry_id" options="{'no_open': 1}" />
+                <field name="product_id" readonly="1" options="{'no_open': 1}" />
                 <field name="price_unit" string="Unit Price" optional="show" widget="monetary"/>
-                <field name="currency_id" optional="hide"/>
-                <field name="uom_id" string="Unit of Measure" optional="show"/>
+                <field name="currency_id" optional="hide" options="{'no_open': 1}" />
+                <field name="uom_id" string="Unit of Measure" optional="show" options="{'no_open': 1}" />
                 <field name="origin" optional="show"/>
                 <field name="product_uom_qty" string="Order Qty" optional="show"/>
                 <field name="qty_received_uom" string="Received Qty" optional="show"/>

--- a/bista_purchase/views/purchase_views.xml
+++ b/bista_purchase/views/purchase_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="bista_orders_report.purchase_order_line_tree_view"/>
         <field name="arch" type="xml">
             <field name="price_total" position="after">
-                <field name="status_id" optional="show" readonly="1" />
+                <field name="status_id" optional="show" readonly="1" options="{'no_open': 1}" />
                 <field name="next_followup_date" optional="show" readonly="1" />
                 <field name="note" optional="show" readonly="1" />
             </field>


### PR DESCRIPTION
only keep the PO number link on the purchase order status report.