### PR TITLE
[IMP] Feature #19436 - only display date instead of receipt date for Dropship transfer and added value on validate date in PDF

### DIFF
--- a/bista_purchase/models/purchase_tracking.py
+++ b/bista_purchase/models/purchase_tracking.py
@@ -66,7 +66,7 @@ class PurchaseTracking(models.Model):
             move_ids = line.po_line_id.move_ids.filtered(lambda m: m.state != "done")
             open_move |= move_ids
             move_ids.write({"quantity_done": line.ship_qty})
-        open_move._action_done()
+        self.order_id.picking_ids._action_done()
         self.status = "shipped"
 
     @api.onchange("checkbox")

--- a/bista_purchase/report/stock_picking.xml
+++ b/bista_purchase/report/stock_picking.xml
@@ -11,7 +11,7 @@
                     <h3>
                         <span t-field="o.name" />
                     </h3>
-                    <t t-if="o.state !='done' and o.picking_type_code =='incoming'">
+                    <t t-if="o.state !='done' and o.picking_type_code =='incoming' and not o.is_dropship">
                         <h5 style="font-size: 20px;">Receipt Date:
                             <span t-field="o.scheduled_date" t-options='{"widget": "date"}' />
                         </h5>
@@ -202,7 +202,7 @@
                     <h3>
                         <span t-field="o.name" />
                     </h3>
-                    <t t-if="o.state !='done' and o.picking_type_code =='incoming'">
+                    <t t-if="o.state !='done' and o.picking_type_code =='incoming' and not o.is_dropship">
                         <h5 style="font-size: 20px;">Receipt Date:
                             <span t-field="o.scheduled_date" t-options='{"widget": "date"}' />
                         </h5>


### PR DESCRIPTION
only display the date instead of the receipt date for the Dropship transfer and added value on validate date in PDF.