### PR TITLE
[IMP] Bug #20322 - Available Payment field only visible who has access of Payment Acquirers menu

### DIFF
--- a/bista_sale/models/res_partner.py
+++ b/bista_sale/models/res_partner.py
@@ -18,4 +18,5 @@ class ResPartner(models.Model):
         "payment.acquirer",
         string="Available Payments",
         domain=lambda self: self._get_available_acquirer(),
+        groups="base.group_system",
     )

--- a/bista_sale/models/sale_order.py
+++ b/bista_sale/models/sale_order.py
@@ -103,6 +103,7 @@ class SaleOrder(models.Model):
         "payment.acquirer",
         string="Available Payments",
         domain=lambda self: self._get_available_acquirer(),
+        groups="base.group_system",
     )
     customer_po_link = fields.Char("Customer PO Link")
     book_use_email = fields.Char()


### PR DESCRIPTION
The available Payment field is only visible who have access to the Payment Acquirers menu.