### PR TITLE
[IMP] Bug #20945 - calculate avatax tax after invoice created from sale order

### DIFF
--- a/bista_bigcommerce_extend/models/sale_order.py
+++ b/bista_bigcommerce_extend/models/sale_order.py
@@ -39,6 +39,7 @@ class SaleOrderVts(models.Model):
                 lambda s: s.big_commerce_order_id
             ):
                 move.write({"fiscal_position_id": False})
+        moves.button_update_avatax()
         return moves
 
     def action_confirm(self):


### PR DESCRIPTION
calculate avatax tax after the invoice is created from the sale order.